### PR TITLE
Fix typo on the return type of DeviceInterface

### DIFF
--- a/src/DeviceInterface.php
+++ b/src/DeviceInterface.php
@@ -4,7 +4,7 @@
 interface DeviceInterface
 {
 
-    public static function find(string $id): Self;
+    public static function find(string $id): self;
 
     public function getName(): string;
 


### PR DESCRIPTION
There was a small typo in the return statement for the `find` method that does not allows returning the current Device instance